### PR TITLE
Translation support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,14 @@ all:
 	@cp $(CURDIR)/emuiibo/toolbox.json $(CURDIR)/SdOut/atmosphere/contents/0100000000000352/toolbox.json
 	@mkdir -p $(CURDIR)/SdOut/switch/.overlays
 	@cp $(CURDIR)/overlay/emuiibo.ovl $(CURDIR)/SdOut/switch/.overlays/emuiibo.ovl
+	@cp -r $(CURDIR)/overlay/emuiibo $(CURDIR)/SdOut/switch/.overlays/
 
 clean:
 	@rm -rf $(CURDIR)/SdOut
 	@cd emuiibo; xargo clean
 	@$(MAKE) clean -C overlay/
+
+translation:
+	$(CURDIR)/overlay/tools/translation.py update ru $(ARGS)
+	$(CURDIR)/overlay/tools/translation.py update de $(ARGS)
+	$(CURDIR)/overlay/tools/translation.py update es $(ARGS)

--- a/overlay/emuiibo/lng_de.json
+++ b/overlay/emuiibo/lng_de.json
@@ -1,0 +1,175 @@
+{
+    "metadata": {
+        "base": "en",
+        "language": "de",
+        "created": "2021-4-9",
+        "author": "AmonRaNet"
+    },
+    "strings": [
+        {
+            "context": "UPNG",
+            "source": "Bad file",
+            "translation": "Ungültige Datei"
+        },
+        {
+            "context": "UPNG",
+            "source": "Please use RGBA PNG.",
+            "translation": "Bitte verwenden Sie RGBA PNG."
+        },
+        {
+            "context": "UPNG",
+            "source": "Upscale not allowed.",
+            "translation": "Upscale nicht erlaubt."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image is too big.",
+            "translation": "Bild ist zu groß."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image not found.",
+            "translation": "Bild nicht gefunden."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image is not a PNG.",
+            "translation": "Bild ist kein PNG."
+        },
+        {
+            "context": "UPNG",
+            "source": "PNG malformed.",
+            "translation": "PNG fehlerhaft."
+        },
+        {
+            "context": "UPNG",
+            "source": "This PNG not supported.",
+            "translation": "Dieses PNG wird nicht unterstützt."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image interlacing is not supported.",
+            "translation": "Bild Interlacing wird nicht unterstützt."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image color format is not supported.",
+            "translation": "Das Bildfarbformat wird nicht unterstützt."
+        },
+        {
+            "context": "UPNG",
+            "source": "Invalid parameter.",
+            "translation": "Ungültiger Parameter."
+        },
+        {
+            "context": "",
+            "source": "emuiibo not found...",
+            "translation": "emuiibo nicht gefunden ..."
+        },
+        {
+            "context": "",
+            "source": "Help",
+            "translation": "Hilfe"
+        },
+        {
+            "context": "",
+            "source": "Enable emulation",
+            "translation": "Emulation aktivieren"
+        },
+        {
+            "context": "",
+            "source": "Disable emulation",
+            "translation": "Emulation deaktivieren"
+        },
+        {
+            "context": "",
+            "source": "Connect/disconnect virtual amiibo",
+            "translation": "Virtuelles Amiibo verbinden/trennen"
+        },
+        {
+            "context": "",
+            "source": "Select folder/virtual amiibo",
+            "translation": "Ordner/virtuelles Amiibo auswählen"
+        },
+        {
+            "context": "",
+            "source": "Add to favorites",
+            "translation": "Zu Favoriten hinzufügen"
+        },
+        {
+            "context": "",
+            "source": "Remove from favorites",
+            "translation": "Aus Favoriten entfernen"
+        },
+        {
+            "context": "",
+            "source": "Reset active amiibo",
+            "translation": "Aktives Amiibo zurücksetzen"
+        },
+        {
+            "context": "",
+            "source": "Emulation status",
+            "translation": "Emulationsstatus"
+        },
+        {
+            "context": "",
+            "source": "on",
+            "translation": "an"
+        },
+        {
+            "context": "",
+            "source": "off",
+            "translation": "aus"
+        },
+        {
+            "context": "",
+            "source": "Current game is",
+            "translation": "Aktuelles Spiel ist"
+        },
+        {
+            "context": "",
+            "source": "Available amiibos in",
+            "translation": "Verfügbare Amiibos in"
+        },
+        {
+            "context": "",
+            "source": "intercepted",
+            "translation": "abgefangen"
+        },
+        {
+            "context": "",
+            "source": "not intercepted",
+            "translation": "nicht abgefangen"
+        },
+        {
+            "context": "",
+            "source": "No active virtual amiibo",
+            "translation": "Kein aktives virtuelles Amiibo"
+        },
+        {
+            "context": "",
+            "source": "connected",
+            "translation": "verbunden"
+        },
+        {
+            "context": "",
+            "source": "disconnected",
+            "translation": "getrennt"
+        },
+        {
+            "context": "",
+            "source": "View amiibos",
+            "translation": "Amiibos anzeigen"
+        },
+        {
+            "context": "",
+            "source": "Favorites",
+            "translation": "Favoriten"
+        },
+        {
+            "context": "",
+            "source": "Reset active",
+            "translation": "Aktives zurücksetzen"
+        }
+    ]
+}

--- a/overlay/emuiibo/lng_es.json
+++ b/overlay/emuiibo/lng_es.json
@@ -1,0 +1,175 @@
+{
+    "metadata": {
+        "base": "en",
+        "language": "es",
+        "created": "2021-4-18",
+        "author": "Impeeza"
+    },
+    "strings": [
+        {
+            "context": "UPNG",
+            "source": "Bad file",
+            "translation": "Archivo Inválido"
+        },
+        {
+            "context": "UPNG",
+            "source": "Please use RGBA PNG.",
+            "translation": "Por favor utilizar un archivo PNG en formato RGBA."
+        },
+        {
+            "context": "UPNG",
+            "source": "Upscale not allowed.",
+            "translation": "No se permite escalar la Imagen."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image is too big.",
+            "translation": "Imagen muy grande."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image not found.",
+            "translation": "Imagen no econtrada."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image is not a PNG.",
+            "translation": "Imagen no es un archivo PNG."
+        },
+        {
+            "context": "UPNG",
+            "source": "PNG malformed.",
+            "translation": "Archivo con formato PNG erróneo."
+        },
+        {
+            "context": "UPNG",
+            "source": "This PNG not supported.",
+            "translation": "No se soporta éste archivo PNG."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image interlacing is not supported.",
+            "translation": "No se soportan imagénes interlaceadas."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image color format is not supported.",
+            "translation": "Formato de color de la imagen no es soportado."
+        },
+        {
+            "context": "UPNG",
+            "source": "Invalid parameter.",
+            "translation": "Parámetro incorrecto."
+        },
+        {
+            "context": "",
+            "source": "emuiibo not found...",
+            "translation": "Emuiibo no econtrado ..."
+        },
+        {
+            "context": "",
+            "source": "Help",
+            "translation": "Ayuda"
+        },
+        {
+            "context": "",
+            "source": "Enable emulation",
+            "translation": "Habilitar emulación"
+        },
+        {
+            "context": "",
+            "source": "Disable emulation",
+            "translation": "Desactivar emulación"
+        },
+        {
+            "context": "",
+            "source": "Connect/disconnect virtual amiibo",
+            "translation": "Conectar/Desconectar amiibo virtual"
+        },
+        {
+            "context": "",
+            "source": "Select folder/virtual amiibo",
+            "translation": "Selecionar carpeta/amiibo virtual"
+        },
+        {
+            "context": "",
+            "source": "Add to favorites",
+            "translation": "Adicionar a favoritos"
+        },
+        {
+            "context": "",
+            "source": "Remove from favorites",
+            "translation": "Remover de favoritos"
+        },
+        {
+            "context": "",
+            "source": "Reset active amiibo",
+            "translation": "Restablecer amiibo activo"
+        },
+        {
+            "context": "",
+            "source": "Emulation status",
+            "translation": "Estado de la emulacioón"
+        },
+        {
+            "context": "",
+            "source": "on",
+            "translation": "Encendido"
+        },
+        {
+            "context": "",
+            "source": "off",
+            "translation": "Apagado"
+        },
+        {
+            "context": "",
+            "source": "Current game is",
+            "translation": "El juego actual"
+        },
+        {
+            "context": "",
+            "source": "Available amiibos in",
+            "translation": "Amiibos disponibles en"
+        },
+        {
+            "context": "",
+            "source": "intercepted",
+            "translation": "ésta siendo interceptado"
+        },
+        {
+            "context": "",
+            "source": "not intercepted",
+            "translation": "NO ésta siendo interceptado"
+        },
+        {
+            "context": "",
+            "source": "No active virtual amiibo",
+            "translation": "No hay amiibo virtual activo"
+        },
+        {
+            "context": "",
+            "source": "connected",
+            "translation": "conectado"
+        },
+        {
+            "context": "",
+            "source": "disconnected",
+            "translation": "desconectado"
+        },
+        {
+            "context": "",
+            "source": "View amiibos",
+            "translation": "Ver Amiibos"
+        },
+        {
+            "context": "",
+            "source": "Favorites",
+            "translation": "Favoritos"
+        },
+        {
+            "context": "",
+            "source": "Reset active",
+            "translation": "Restablecer activo"
+        }
+    ]
+}

--- a/overlay/emuiibo/lng_ru.json
+++ b/overlay/emuiibo/lng_ru.json
@@ -1,0 +1,175 @@
+{
+    "metadata": {
+        "base": "en",
+        "language": "ru",
+        "created": "2021-2-11",
+        "author": "AmonRaNet"
+    },
+    "strings": [
+        {
+            "context": "UPNG",
+            "source": "Bad file",
+            "translation": "Плохой файл"
+        },
+        {
+            "context": "UPNG",
+            "source": "Please use RGBA PNG.",
+            "translation": "Требуется RGBA PNG."
+        },
+        {
+            "context": "UPNG",
+            "source": "Upscale not allowed.",
+            "translation": "Скалирование запрещено."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image is too big.",
+            "translation": "Картинка слишком большая."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image not found.",
+            "translation": "Картинка не найдена."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image is not a PNG.",
+            "translation": "Картинка не PNG."
+        },
+        {
+            "context": "UPNG",
+            "source": "PNG malformed.",
+            "translation": "PNG испорчен."
+        },
+        {
+            "context": "UPNG",
+            "source": "This PNG not supported.",
+            "translation": "Этот PNG не поддерживается."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image interlacing is not supported.",
+            "translation": "interlacing не поддерживается."
+        },
+        {
+            "context": "UPNG",
+            "source": "Image color format is not supported.",
+            "translation": "Формат цвета  не поддерживается."
+        },
+        {
+            "context": "UPNG",
+            "source": "Invalid parameter.",
+            "translation": "Ошибка параметра."
+        },
+        {
+            "context": "",
+            "source": "emuiibo not found...",
+            "translation": "emuiibo сервис не найден..."
+        },
+        {
+            "context": "",
+            "source": "Help",
+            "translation": "Помощь"
+        },
+        {
+            "context": "",
+            "source": "Enable emulation",
+            "translation": "Включить эмуляцию"
+        },
+        {
+            "context": "",
+            "source": "Disable emulation",
+            "translation": "Выключить эмуляцию"
+        },
+        {
+            "context": "",
+            "source": "Connect/disconnect virtual amiibo",
+            "translation": "Подключить/отключить виртуальный amiibo"
+        },
+        {
+            "context": "",
+            "source": "Select folder/virtual amiibo",
+            "translation": "Выбрать папку/виртуальный amiibo"
+        },
+        {
+            "context": "",
+            "source": "Add to favorites",
+            "translation": "Добавить в избранное"
+        },
+        {
+            "context": "",
+            "source": "Remove from favorites",
+            "translation": "Удалить из избранного"
+        },
+        {
+            "context": "",
+            "source": "Reset active amiibo",
+            "translation": "Сбросить активный amiibo"
+        },
+        {
+            "context": "",
+            "source": "Emulation status",
+            "translation": "Статус эмуляции"
+        },
+        {
+            "context": "",
+            "source": "on",
+            "translation": "вкл"
+        },
+        {
+            "context": "",
+            "source": "off",
+            "translation": "выкл"
+        },
+        {
+            "context": "",
+            "source": "Current game is",
+            "translation": "Текущая игра"
+        },
+        {
+            "context": "",
+            "source": "Available amiibos in",
+            "translation": "Доступные amiibos в"
+        },
+        {
+            "context": "",
+            "source": "intercepted",
+            "translation": "перехватывается"
+        },
+        {
+            "context": "",
+            "source": "not intercepted",
+            "translation": "не перехватывается"
+        },
+        {
+            "context": "",
+            "source": "No active virtual amiibo",
+            "translation": "Виртуальный amiibo не выбран"
+        },
+        {
+            "context": "",
+            "source": "connected",
+            "translation": "подключен"
+        },
+        {
+            "context": "",
+            "source": "disconnected",
+            "translation": "отключен"
+        },
+        {
+            "context": "",
+            "source": "View amiibos",
+            "translation": "Просмотр amiibos"
+        },
+        {
+            "context": "",
+            "source": "Favorites",
+            "translation": "Избранное"
+        },
+        {
+            "context": "",
+            "source": "Reset active",
+            "translation": "Сбросить активный"
+        }
+    ]
+}

--- a/overlay/include/json.hpp
+++ b/overlay/include/json.hpp
@@ -1,0 +1,789 @@
+/*
+ *  -- SimpleJSON.hpp
+ *  Developed by: https://github.com/nbsdx/
+ *  Forked by: https://github.com/SealtielFreak/
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef JSON_HPP
+#define JSON_HPP
+
+#include <cstdint>
+#include <cmath>
+#include <cctype>
+#include <string>
+#include <deque>
+#include <map>
+#include <type_traits>
+#include <initializer_list>
+#include <ostream>
+#include <iostream>
+
+namespace json {
+
+    using std::map;
+    using std::deque;
+    using std::string;
+    using std::enable_if;
+    using std::initializer_list;
+    using std::is_same;
+    using std::is_convertible;
+    using std::is_integral;
+    using std::is_floating_point;
+
+    namespace {
+        string json_escape(const string &str) {
+            string output;
+            for (unsigned i = 0; i < str.length(); ++i)
+                switch (str[i]) {
+                    case '\"':
+                        output += "\\\"";
+                        break;
+                    case '\\':
+                        output += "\\\\";
+                        break;
+                    case '\b':
+                        output += "\\b";
+                        break;
+                    case '\f':
+                        output += "\\f";
+                        break;
+                    case '\n':
+                        output += "\\n";
+                        break;
+                    case '\r':
+                        output += "\\r";
+                        break;
+                    case '\t':
+                        output += "\\t";
+                        break;
+                    default  :
+                        output += str[i];
+                        break;
+                }
+            return std::move(output);
+        }
+    }
+
+    class JSON {
+        union BackingData {
+            BackingData(double d) : Float(d) {}
+
+            BackingData(long l) : Int(l) {}
+
+            BackingData(bool b) : Bool(b) {}
+
+            BackingData(string s) : String(new string(s)) {}
+
+            BackingData() : Int(0) {}
+
+            deque <JSON> *List;
+            map <string, JSON> *Map;
+            string *String;
+            double Float;
+            long Int;
+            bool Bool;
+        } Internal;
+
+    public:
+        enum class Class {
+            Null,
+            Object,
+            Array,
+            String,
+            Floating,
+            Integral,
+            Boolean
+        };
+
+        template<typename Container>
+        class JSONWrapper {
+            Container *object;
+
+        public:
+            JSONWrapper(Container *val) : object(val) {}
+
+            JSONWrapper(std::nullptr_t) : object(nullptr) {}
+
+            typename Container::iterator begin() { return object ? object->begin() : typename Container::iterator(); }
+
+            typename Container::iterator end() { return object ? object->end() : typename Container::iterator(); }
+
+            typename Container::const_iterator begin() const {
+                return object ? object->begin() : typename Container::iterator();
+            }
+
+            typename Container::const_iterator end() const {
+                return object ? object->end() : typename Container::iterator();
+            }
+        };
+
+        template<typename Container>
+        class JSONConstWrapper {
+            const Container *object;
+
+        public:
+            JSONConstWrapper(const Container *val) : object(val) {}
+
+            JSONConstWrapper(std::nullptr_t) : object(nullptr) {}
+
+            typename Container::const_iterator begin() const {
+                return object ? object->begin() : typename Container::const_iterator();
+            }
+
+            typename Container::const_iterator end() const {
+                return object ? object->end() : typename Container::const_iterator();
+            }
+        };
+
+        JSON() : Internal(), Type(Class::Null) {}
+
+        JSON(initializer_list <JSON> list)
+                : JSON() {
+            SetType(Class::Object);
+            for (auto i = list.begin(), e = list.end(); i != e; ++i, ++i)
+                operator[](i->ToString()) = *std::next(i);
+        }
+
+        JSON(JSON &&other)
+                : Internal(other.Internal), Type(other.Type) {
+            other.Type = Class::Null;
+            other.Internal.Map = nullptr;
+        }
+
+        JSON &operator=(JSON &&other) {
+            ClearInternal();
+            Internal = other.Internal;
+            Type = other.Type;
+            other.Internal.Map = nullptr;
+            other.Type = Class::Null;
+            return *this;
+        }
+
+        JSON(const JSON &other) {
+            switch (other.Type) {
+                case Class::Object:
+                    Internal.Map =
+                            new map<string, JSON>(other.Internal.Map->begin(),
+                                                  other.Internal.Map->end());
+                    break;
+                case Class::Array:
+                    Internal.List =
+                            new deque<JSON>(other.Internal.List->begin(),
+                                            other.Internal.List->end());
+                    break;
+                case Class::String:
+                    Internal.String =
+                            new string(*other.Internal.String);
+                    break;
+                default:
+                    Internal = other.Internal;
+            }
+            Type = other.Type;
+        }
+
+        JSON &operator=(const JSON &other) {
+            ClearInternal();
+            switch (other.Type) {
+                case Class::Object:
+                    Internal.Map =
+                            new map<string, JSON>(other.Internal.Map->begin(),
+                                                  other.Internal.Map->end());
+                    break;
+                case Class::Array:
+                    Internal.List =
+                            new deque<JSON>(other.Internal.List->begin(),
+                                            other.Internal.List->end());
+                    break;
+                case Class::String:
+                    Internal.String =
+                            new string(*other.Internal.String);
+                    break;
+                default:
+                    Internal = other.Internal;
+            }
+            Type = other.Type;
+            return *this;
+        }
+
+        ~JSON() {
+            switch (Type) {
+                case Class::Array:
+                    delete Internal.List;
+                    break;
+                case Class::Object:
+                    delete Internal.Map;
+                    break;
+                case Class::String:
+                    delete Internal.String;
+                    break;
+                default:;
+            }
+        }
+
+        template<typename T>
+        JSON(T b, typename enable_if<is_same<T, bool>::value>::type * = 0) : Internal(b), Type(Class::Boolean) {}
+
+        template<typename T>
+        JSON(T i, typename enable_if<is_integral<T>::value && !is_same<T, bool>::value>::type * = 0) : Internal(
+                (long) i), Type(Class::Integral) {}
+
+        template<typename T>
+        JSON(T f, typename enable_if<is_floating_point<T>::value>::type * = 0) : Internal((double) f),
+                                                                                 Type(Class::Floating) {}
+
+        template<typename T>
+        JSON(T s, typename enable_if<is_convertible<T, string>::value>::type * = 0) : Internal(string(s)),
+                                                                                      Type(Class::String) {}
+
+        JSON(std::nullptr_t) : Internal(), Type(Class::Null) {}
+
+        static JSON Make(Class type) {
+            JSON ret;
+            ret.SetType(type);
+            return ret;
+        }
+
+        static JSON Load(const string &);
+
+        template<typename T>
+        void append(T arg) {
+            SetType(Class::Array);
+            Internal.List->emplace_back(arg);
+        }
+
+        template<typename T, typename... U>
+        void append(T arg, U... args) {
+            append(arg);
+            append(args...);
+        }
+
+        template<typename T>
+        typename enable_if<is_same<T, bool>::value, JSON &>::type operator=(T b) {
+            SetType(Class::Boolean);
+            Internal.Bool = b;
+            return *this;
+        }
+
+        template<typename T>
+        typename enable_if<is_integral<T>::value && !is_same<T, bool>::value, JSON &>::type operator=(T i) {
+            SetType(Class::Integral);
+            Internal.Int = i;
+            return *this;
+        }
+
+        template<typename T>
+        typename enable_if<is_floating_point<T>::value, JSON &>::type operator=(T f) {
+            SetType(Class::Floating);
+            Internal.Float = f;
+            return *this;
+        }
+
+        template<typename T>
+        typename enable_if<is_convertible<T, string>::value, JSON &>::type operator=(T s) {
+            SetType(Class::String);
+            *Internal.String = string(s);
+            return *this;
+        }
+
+        JSON &operator[](const string &key) {
+            SetType(Class::Object);
+            return Internal.Map->operator[](key);
+        }
+
+        JSON &operator[](unsigned index) {
+            SetType(Class::Array);
+            if (index >= Internal.List->size()) Internal.List->resize(index + 1);
+            return Internal.List->operator[](index);
+        }
+
+        JSON &at(const string &key) {
+            return operator[](key);
+        }
+
+        const JSON &at(const string &key) const {
+            return Internal.Map->at(key);
+        }
+
+        JSON &at(unsigned index) {
+            return operator[](index);
+        }
+
+        const JSON &at(unsigned index) const {
+            return Internal.List->at(index);
+        }
+
+        int length() const {
+            if (Type == Class::Array)
+                return Internal.List->size();
+            else
+                return -1;
+        }
+
+        bool hasKey(const string &key) const {
+            if (Type == Class::Object)
+                return Internal.Map->find(key) != Internal.Map->end();
+            return false;
+        }
+
+        int size() const {
+            if (Type == Class::Object)
+                return Internal.Map->size();
+            else if (Type == Class::Array)
+                return Internal.List->size();
+            else
+                return -1;
+        }
+
+        Class JSONType() const { return Type; }
+
+        /// Functions for getting primitives from the JSON object.
+        bool IsNull() const { return Type == Class::Null; }
+
+        string ToString() const {
+            bool b;
+            return std::move(ToString(b));
+        }
+
+        string ToString(bool &ok) const {
+            ok = (Type == Class::String);
+            return ok ? std::move(json_escape(*Internal.String)) : string("");
+        }
+
+        double ToFloat() const {
+            bool b;
+            return ToFloat(b);
+        }
+
+        double ToFloat(bool &ok) const {
+            ok = (Type == Class::Floating);
+            return ok ? Internal.Float : 0.0;
+        }
+
+        long ToInt() const {
+            bool b;
+            return ToInt(b);
+        }
+
+        long ToInt(bool &ok) const {
+            ok = (Type == Class::Integral);
+            return ok ? Internal.Int : 0;
+        }
+
+        bool ToBool() const {
+            bool b;
+            return ToBool(b);
+        }
+
+        bool ToBool(bool &ok) const {
+            ok = (Type == Class::Boolean);
+            return ok ? Internal.Bool : false;
+        }
+
+        JSONWrapper<map < string, JSON>> ObjectRange() {
+            if (Type == Class::Object)
+                return JSONWrapper<map < string, JSON>>
+            (Internal.Map);
+            return JSONWrapper<map < string, JSON>>
+            (nullptr);
+        }
+
+        JSONWrapper<deque < JSON>> ArrayRange() {
+            if (Type == Class::Array)
+                return JSONWrapper<deque < JSON>>
+            (Internal.List);
+            return JSONWrapper<deque < JSON>>
+            (nullptr);
+        }
+
+        JSONConstWrapper<map < string, JSON>> ObjectRange() const {
+            if (Type == Class::Object)
+                return JSONConstWrapper<map < string, JSON>>
+            (Internal.Map);
+            return JSONConstWrapper<map < string, JSON>>
+            (nullptr);
+        }
+
+
+        JSONConstWrapper<deque < JSON>> ArrayRange() const {
+            if (Type == Class::Array)
+                return JSONConstWrapper<deque < JSON>>
+            (Internal.List);
+            return JSONConstWrapper<deque < JSON>>
+            (nullptr);
+        }
+
+        string dump(int depth = 1, string tab = "  ") const {
+            string pad = "";
+            for (int i = 0; i < depth; ++i, pad += tab);
+
+            switch (Type) {
+                case Class::Null:
+                    return "null";
+                case Class::Object: {
+                    string s = "{\n";
+                    bool skip = true;
+                    for (auto &p : *Internal.Map) {
+                        if (!skip) s += ",\n";
+                        s += (pad + "\"" + p.first + "\" : " + p.second.dump(depth + 1, tab));
+                        skip = false;
+                    }
+                    s += ("\n" + pad.erase(0, 2) + "}");
+                    return s;
+                }
+                case Class::Array: {
+                    string s = "[";
+                    bool skip = true;
+                    for (auto &p : *Internal.List) {
+                        if (!skip) s += ", ";
+                        s += p.dump(depth + 1, tab);
+                        skip = false;
+                    }
+                    s += "]";
+                    return s;
+                }
+                case Class::String:
+                    return "\"" + json_escape(*Internal.String) + "\"";
+                case Class::Floating:
+                    return std::to_string(Internal.Float);
+                case Class::Integral:
+                    return std::to_string(Internal.Int);
+                case Class::Boolean:
+                    return Internal.Bool ? "true" : "false";
+                default:
+                    return "";
+            }
+            return "";
+        }
+
+        friend std::ostream &operator<<(std::ostream &, const JSON &);
+
+    private:
+        void SetType(Class type) {
+            if (type == Type)
+                return;
+
+            ClearInternal();
+
+            switch (type) {
+                case Class::Null:
+                    Internal.Map = nullptr;
+                    break;
+                case Class::Object:
+                    Internal.Map = new map<string, JSON>();
+                    break;
+                case Class::Array:
+                    Internal.List = new deque<JSON>();
+                    break;
+                case Class::String:
+                    Internal.String = new string();
+                    break;
+                case Class::Floating:
+                    Internal.Float = 0.0;
+                    break;
+                case Class::Integral:
+                    Internal.Int = 0;
+                    break;
+                case Class::Boolean:
+                    Internal.Bool = false;
+                    break;
+            }
+
+            Type = type;
+        }
+
+    private:
+        /* beware: only call if YOU know that Internal is allocated. No checks performed here.
+           This function should be called in a constructed JSON just before you are going to
+          overwrite Internal...
+        */
+        void ClearInternal() {
+            switch (Type) {
+                case Class::Object:
+                    delete Internal.Map;
+                    break;
+                case Class::Array:
+                    delete Internal.List;
+                    break;
+                case Class::String:
+                    delete Internal.String;
+                    break;
+                default:;
+            }
+        }
+
+    private:
+
+        Class Type = Class::Null;
+    };
+
+    JSON Array() {
+        return std::move(JSON::Make(JSON::Class::Array));
+    }
+
+    template<typename... T>
+    JSON Array(T... args) {
+        JSON arr = JSON::Make(JSON::Class::Array);
+        arr.append(args...);
+        return std::move(arr);
+    }
+
+    JSON Object() {
+        return std::move(JSON::Make(JSON::Class::Object));
+    }
+
+    std::ostream &operator<<(std::ostream &os, const JSON &json) {
+        os << json.dump();
+        return os;
+    }
+
+    namespace {
+        JSON parse_next(const string &, size_t &);
+
+        void consume_ws(const string &str, size_t &offset) {
+            while (isspace(str[offset])) ++offset;
+        }
+
+        JSON parse_object(const string &str, size_t &offset) {
+            JSON Object = JSON::Make(JSON::Class::Object);
+
+            ++offset;
+            consume_ws(str, offset);
+            if (str[offset] == '}') {
+                ++offset;
+                return std::move(Object);
+            }
+
+            while (true) {
+                JSON Key = parse_next(str, offset);
+                consume_ws(str, offset);
+                if (str[offset] != ':') {
+                    std::cerr << "Error: Object: Expected colon, found '" << str[offset] << "'\n";
+                    break;
+                }
+                consume_ws(str, ++offset);
+                JSON Value = parse_next(str, offset);
+                Object[Key.ToString()] = Value;
+
+                consume_ws(str, offset);
+                if (str[offset] == ',') {
+                    ++offset;
+                    continue;
+                } else if (str[offset] == '}') {
+                    ++offset;
+                    break;
+                } else {
+                    std::cerr << "ERROR: Object: Expected comma, found '" << str[offset] << "'\n";
+                    break;
+                }
+            }
+
+            return std::move(Object);
+        }
+
+        JSON parse_array(const string &str, size_t &offset) {
+            JSON Array = JSON::Make(JSON::Class::Array);
+            unsigned index = 0;
+
+            ++offset;
+            consume_ws(str, offset);
+            if (str[offset] == ']') {
+                ++offset;
+                return std::move(Array);
+            }
+
+            while (true) {
+                Array[index++] = parse_next(str, offset);
+                consume_ws(str, offset);
+
+                if (str[offset] == ',') {
+                    ++offset;
+                    continue;
+                } else if (str[offset] == ']') {
+                    ++offset;
+                    break;
+                } else {
+                    std::cerr << "ERROR: Array: Expected ',' or ']', found '" << str[offset] << "'\n";
+                    return std::move(JSON::Make(JSON::Class::Array));
+                }
+            }
+
+            return std::move(Array);
+        }
+
+        JSON parse_string(const string &str, size_t &offset) {
+            JSON String;
+            string val;
+            for (char c = str[++offset]; c != '\"'; c = str[++offset]) {
+                if (c == '\\') {
+                    switch (str[++offset]) {
+                        case '\"':
+                            val += '\"';
+                            break;
+                        case '\\':
+                            val += '\\';
+                            break;
+                        case '/' :
+                            val += '/';
+                            break;
+                        case 'b' :
+                            val += '\b';
+                            break;
+                        case 'f' :
+                            val += '\f';
+                            break;
+                        case 'n' :
+                            val += '\n';
+                            break;
+                        case 'r' :
+                            val += '\r';
+                            break;
+                        case 't' :
+                            val += '\t';
+                            break;
+                        case 'u' : {
+                            val += "\\u";
+                            for (unsigned i = 1; i <= 4; ++i) {
+                                c = str[offset + i];
+                                if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))
+                                    val += c;
+                                else {
+                                    std::cerr << "ERROR: String: Expected hex character in unicode escape, found '" << c
+                                              << "'\n";
+                                    return std::move(JSON::Make(JSON::Class::String));
+                                }
+                            }
+                            offset += 4;
+                        }
+                            break;
+                        default  :
+                            val += '\\';
+                            break;
+                    }
+                } else
+                    val += c;
+            }
+            ++offset;
+            String = val;
+            return std::move(String);
+        }
+
+        JSON parse_number(const string &str, size_t &offset) {
+            JSON Number;
+            string val, exp_str;
+            char c;
+            bool isDouble = false;
+            long exp = 0;
+            while (true) {
+                c = str[offset++];
+                if ((c == '-') || (c >= '0' && c <= '9'))
+                    val += c;
+                else if (c == '.') {
+                    val += c;
+                    isDouble = true;
+                } else
+                    break;
+            }
+            if (c == 'E' || c == 'e') {
+                c = str[offset++];
+                if (c == '-') {
+                    ++offset;
+                    exp_str += '-';
+                }
+                while (true) {
+                    c = str[offset++];
+                    if (c >= '0' && c <= '9')
+                        exp_str += c;
+                    else if (!isspace(c) && c != ',' && c != ']' && c != '}') {
+                        std::cerr << "ERROR: Number: Expected a number for exponent, found '" << c << "'\n";
+                        return std::move(JSON::Make(JSON::Class::Null));
+                    } else
+                        break;
+                }
+                exp = std::stol(exp_str);
+            } else if (!isspace(c) && c != ',' && c != ']' && c != '}') {
+                std::cerr << "ERROR: Number: unexpected character '" << c << "'\n";
+                return std::move(JSON::Make(JSON::Class::Null));
+            }
+            --offset;
+
+            if (isDouble)
+                Number = std::stod(val) * std::pow(10, exp);
+            else {
+                if (!exp_str.empty())
+                    Number = std::stol(val) * std::pow(10, exp);
+                else
+                    Number = std::stol(val);
+            }
+            return std::move(Number);
+        }
+
+        JSON parse_bool(const string &str, size_t &offset) {
+            JSON Bool;
+            if (str.substr(offset, 4) == "true")
+                Bool = true;
+            else if (str.substr(offset, 5) == "false")
+                Bool = false;
+            else {
+                std::cerr << "ERROR: Bool: Expected 'true' or 'false', found '" << str.substr(offset, 5) << "'\n";
+                return std::move(JSON::Make(JSON::Class::Null));
+            }
+            offset += (Bool.ToBool() ? 4 : 5);
+            return std::move(Bool);
+        }
+
+        JSON parse_null(const string &str, size_t &offset) {
+            JSON Null;
+            if (str.substr(offset, 4) != "null") {
+                std::cerr << "ERROR: Null: Expected 'null', found '" << str.substr(offset, 4) << "'\n";
+                return std::move(JSON::Make(JSON::Class::Null));
+            }
+            offset += 4;
+            return std::move(Null);
+        }
+
+        JSON parse_next(const string &str, size_t &offset) {
+            char value;
+            consume_ws(str, offset);
+            value = str[offset];
+            switch (value) {
+                case '[' :
+                    return std::move(parse_array(str, offset));
+                case '{' :
+                    return std::move(parse_object(str, offset));
+                case '\"':
+                    return std::move(parse_string(str, offset));
+                case 't' :
+                case 'f' :
+                    return std::move(parse_bool(str, offset));
+                case 'n' :
+                    return std::move(parse_null(str, offset));
+                default  :
+                    if ((value <= '9' && value >= '0') || value == '-')
+                        return std::move(parse_number(str, offset));
+            }
+            std::cerr << "ERROR: Parse: Unknown starting character '" << value << "'\n";
+            return JSON();
+        }
+    }
+
+    JSON JSON::Load(const string &str) {
+        size_t offset = 0;
+        return std::move(parse_next(str, offset));
+    }
+
+} // End Namespace json
+
+#endif // JSON_HPP

--- a/overlay/include/translation.h
+++ b/overlay/include/translation.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#define TR(SOURCE) Translator::translate(SOURCE)
+#define TR_CTX(SOURCE, CONTEXT) Translator::translate(SOURCE, CONTEXT)
+
+class Translator {
+
+public:
+    static Translator& global();
+    static std::string translate(const std::string& source, const std::string& context = {});
+
+    void loadSystem();
+
+    //https://switchbrew.org/wiki/Settings_services#LanguageCode
+    void loadCustom(const std::string& lng);
+
+    std::string get(const std::string& source, const std::string& context) const;
+
+private:
+    std::string language;
+    std::unordered_map<std::string, std::unordered_map<std::string, std::string>> strings;
+};

--- a/overlay/source/Main.cpp
+++ b/overlay/source/Main.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <set>
 #include <upng.h>
+#include <translation.h>
 
 namespace {
     enum Action : u64 {
@@ -59,6 +60,7 @@ namespace {
     std::string favoritesFile() {
         return "favorites.txt";
     }
+
 }
 
 class PngImage {
@@ -85,7 +87,7 @@ class PngImage {
             tsl::hlp::doWithSDCardHandle([this, max_height, max_width] {
                 upng_t* upng = upng_new_from_file(path.c_str());
                 if (upng == NULL) {
-                    setError("Bad file");
+                    setError(TR_CTX("Bad file", "UPNG"));
                     return;
                 }
                 upng_decode(upng);
@@ -96,7 +98,7 @@ class PngImage {
                         *  DELETE ONCE RGB DOWNSCALE WORKS PROPERLY
                         */
                         if (is_rgb){
-                            setError("Please use RGBA PNG.");
+                            setError(TR_CTX("Please use RGBA PNG.", "UPNG"));
                             break;
                         }
                         /* DELETE END */
@@ -110,7 +112,7 @@ class PngImage {
                         double scale2 = (double)max_width / (double)upng_width;
                         double scale = std::min(scale1, scale2);
                         if (scale > 1.0) {
-                            setError("Upscale not allowed.");
+                            setError(TR_CTX("Upscale not allowed.", "UPNG"));
                             break;
                         }
 
@@ -143,35 +145,35 @@ class PngImage {
                         break;
                     }
                     case UPNG_ENOMEM: {
-                        setError("Image is too big.");
+                        setError(TR_CTX("Image is too big.", "UPNG"));
                         break;
                     }
                     case UPNG_ENOTFOUND: {
-                        setError("Image not found.");
+                        setError(TR_CTX("Image not found.", "UPNG"));
                         break;
                     }
                     case UPNG_ENOTPNG: {
-                        setError("Image is not a PNG.");
+                        setError(TR_CTX("Image is not a PNG.", "UPNG"));
                         break;
                     }
                     case UPNG_EMALFORMED: {
-                        setError("PNG malformed.");
+                        setError(TR_CTX("PNG malformed.", "UPNG"));
                         break;
                     }
                     case UPNG_EUNSUPPORTED: {
-                        setError("This PNG not supported.");
+                        setError(TR_CTX("This PNG not supported.", "UPNG"));
                         break;
                     }
                     case UPNG_EUNINTERLACED: {
-                        setError("Image interlacing is not supported.");
+                        setError(TR_CTX("Image interlacing is not supported.", "UPNG"));
                         break;
                     }
                     case UPNG_EUNFORMAT: {
-                        setError("Image color format is not supported.");
+                        setError(TR_CTX("Image color format is not supported.", "UPNG"));
                         break;
                     }
                     case UPNG_EPARAM: {
-                        setError("Invalid parameter.");
+                        setError(TR_CTX("Invalid parameter.", "UPNG"));
                         break;
                     }
                 }
@@ -254,7 +256,7 @@ class EmuiiboState {
 
         std::string getEmuiiboVersionString() const {
             if (!isEmuiiboOk()) {
-                return "emuiibo not found...";
+                return TR("emuiibo not found...");
             }
             const auto& emuiibo_version = getEmuiiboVersion();
             return std::to_string(emuiibo_version.major) + "." + std::to_string(emuiibo_version.minor) + "." + std::to_string(emuiibo_version.micro) + " (" + (emuiibo_version.dev_build ? "dev" : "release") + ")";
@@ -452,12 +454,12 @@ class GuiListElement: public tslext::elm::SmallListItem {
 
 class VirtualListElement: public GuiListElement {
     public:
-        VirtualListElement(std::shared_ptr<EmuiiboState> state, const std::string& label) : GuiListElement(state, {}, label, "..") {}
+        VirtualListElement(std::shared_ptr<EmuiiboState> state, const std::string& label, const std::string& iconGlyph = "") : GuiListElement(state, {}, label + (!iconGlyph.empty() ? " " + iconGlyph : ""), "..") {}
 };
 
 class ActionListElement: public GuiListElement {
     public:
-        ActionListElement(std::shared_ptr<EmuiiboState> state, const std::string& label) : GuiListElement(state, {}, label, "") {}
+        ActionListElement(std::shared_ptr<EmuiiboState> state, const std::string& label, const std::string& iconGlyph = "") : GuiListElement(state, {}, label + (!iconGlyph.empty() ? " " + iconGlyph : ""), "") {}
 };
 
 class FolderListElement: public GuiListElement {
@@ -551,18 +553,18 @@ class AmiiboGuiHelp : public tsl::Gui {
         AmiiboGuiHelp(std::shared_ptr<EmuiiboState> state) : emuiibo{state} {}
 
         virtual tsl::elm::Element* createUI() override {
-            auto root_frame = new tslext::elm::DoubleSectionOverlayFrame("emuiibo help", emuiibo->getEmuiiboVersionString(), tslext::SectionsLayout::big_top, false);
+            auto root_frame = new tslext::elm::DoubleSectionOverlayFrame(TR("Help"), emuiibo->getEmuiiboVersionString(), tslext::SectionsLayout::big_top, false);
             auto top_list = new tsl::elm::List();
             root_frame->setTopSection(top_list);
 
-            top_list->addItem(new tslext::elm::SmallListItem("Help", actionGlyph(Action::ShowHelp)));
-            top_list->addItem(new tslext::elm::SmallListItem("Enable emulation", actionGlyph(Action::EnableEmulation)));
-            top_list->addItem(new tslext::elm::SmallListItem("Disable emulation", actionGlyph(Action::DisableEmulation)));
-            top_list->addItem(new tslext::elm::SmallListItem("Connect/disconnect virtual amiibo", actionGlyph(Action::ToogleConnectAmiibo)));
-            top_list->addItem(new tslext::elm::SmallListItem("Select folder/virtual amiibo", actionGlyph(Action::ActivateItem)));
-            top_list->addItem(new tslext::elm::SmallListItem("Add to favorites", actionGlyph(Action::AddToFavorite)));
-            top_list->addItem(new tslext::elm::SmallListItem("Remove from favorites", actionGlyph(Action::RemoveFromFavorite)));
-            top_list->addItem(new tslext::elm::SmallListItem("Reset active amiibo", actionGlyph(Action::ResetActiveAmiibo)));
+            top_list->addItem(new tslext::elm::SmallListItem(TR("Help"), actionGlyph(Action::ShowHelp)));
+            top_list->addItem(new tslext::elm::SmallListItem(TR("Enable emulation"), actionGlyph(Action::EnableEmulation)));
+            top_list->addItem(new tslext::elm::SmallListItem(TR("Disable emulation"), actionGlyph(Action::DisableEmulation)));
+            top_list->addItem(new tslext::elm::SmallListItem(TR("Connect/disconnect virtual amiibo"), actionGlyph(Action::ToogleConnectAmiibo)));
+            top_list->addItem(new tslext::elm::SmallListItem(TR("Select folder/virtual amiibo"), actionGlyph(Action::ActivateItem)));
+            top_list->addItem(new tslext::elm::SmallListItem(TR("Add to favorites"), actionGlyph(Action::AddToFavorite)));
+            top_list->addItem(new tslext::elm::SmallListItem(TR("Remove from favorites"), actionGlyph(Action::RemoveFromFavorite)));
+            top_list->addItem(new tslext::elm::SmallListItem(TR("Reset active amiibo"), actionGlyph(Action::ResetActiveAmiibo)));
 
             return root_frame;
         }
@@ -651,7 +653,8 @@ class AmiiboGui : public tsl::Gui {
             }
 
             // emuiibo emulation status
-            toggle_item = new tslext::elm::SmallToggleListItem("Emulation status " + actionGlyph(Action::DisableEmulation) + " " + actionGlyph(Action::EnableEmulation), false, "on", "off");
+            toggle_item = new tslext::elm::SmallToggleListItem(TR("Emulation status") + " " + actionGlyph(Action::DisableEmulation) + " " + actionGlyph(Action::EnableEmulation),
+                                                               false, TR("on"), TR("off"));
             toggle_item->setClickListener([&](u64 keys) {
                 if(keys & Action::ActivateItem){
                     emuiibo->toggleEmulationStatus();
@@ -662,7 +665,7 @@ class AmiiboGui : public tsl::Gui {
             top_list->addItem(toggle_item);
 
             // Current game status
-            game_header = new tslext::elm::SmallListItem("Current game is");
+            game_header = new tslext::elm::SmallListItem(TR("Current game is"));
             top_list->addItem(game_header);
 
             // Current amiibo
@@ -674,7 +677,7 @@ class AmiiboGui : public tsl::Gui {
             top_list->addItem(amiibo_icons, maxIconHeigth() + 2 * marginIcon());
 
             // Information about base folder
-            top_list->addItem(new tslext::elm::SmallListItem(std::string("Available amiibos in '") + base_path.filename().string() + "'", std::to_string(amiibo_count)));
+            top_list->addItem(new tslext::elm::SmallListItem(TR("Available amiibos in") + " '" + base_path.filename().string() + "': " + std::to_string(amiibo_count)));
 
             // Main key bindings
             root_frame->setClickListener([&](u64 keys) {
@@ -721,16 +724,16 @@ class AmiiboGui : public tsl::Gui {
                 return;
             }
 
-            game_header->setColoredValue(emuiibo->isCurrentApplicationIdIntercepted() ? "intercepted" : "not intercepted",
+            game_header->setColoredValue(emuiibo->isCurrentApplicationIdIntercepted() ? TR("intercepted") : TR("not intercepted"),
                                          emuiibo->isCurrentApplicationIdIntercepted() ? tsl::style::color::ColorHighlight : tslext::style::color::ColorWarning);
 
             if(emuiibo->isActiveAmiiboValid()) {
                 amiibo_header->setText(std::string(emuiibo->getActiveVirtualAmiiboAmiiboData().name) + " " + actionGlyph(Action::ToogleConnectAmiibo));
             }
             else {
-                amiibo_header->setText("No active virtual amiibo");
+                amiibo_header->setText(TR("No active virtual amiibo"));
             }
-            amiibo_header->setColoredValue(emuiibo->getActiveVirtualAmiiboStatus() == emu::VirtualAmiiboStatus::Connected ? "connected" : "disconnected",
+            amiibo_header->setColoredValue(emuiibo->getActiveVirtualAmiiboStatus() == emu::VirtualAmiiboStatus::Connected ? TR("connected") : TR("disconnected"),
                                            emuiibo->getActiveVirtualAmiiboStatus() == emu::VirtualAmiiboStatus::Connected ? tsl::style::color::ColorHighlight : tslext::style::color::ColorWarning);
 
             if (auto* amiibo_item = dynamic_cast<AmiiboListElement*>(getFocusedElement())) {
@@ -746,24 +749,24 @@ class AmiiboGui : public tsl::Gui {
         }
 
     private:
-        tsl::elm::Element* createRootElement() {
-            auto item = new VirtualListElement(emuiibo, "View amiibos");
+        VirtualListElement* createRootElement() {
+            auto item = new VirtualListElement(emuiibo, TR("View amiibos"));
             item->setActionListener([this] (auto&) {
                 tsl::changeTo<AmiiboGui>(emuiibo, Type::Folder, emuiibo->getEmuiiboVirtualAmiiboPath());
             });
             return item;
         }
 
-        tsl::elm::Element* createFavoritesElement() {
-            auto item = new VirtualListElement(emuiibo, "Favorites " + iconGlyph(Icon::Favorite));
+        VirtualListElement* createFavoritesElement() {
+            auto item = new VirtualListElement(emuiibo, TR("Favorites"), iconGlyph(Icon::Favorite));
             item->setActionListener([this](auto&) {
                 tsl::changeTo<AmiiboGui>(emuiibo, Type::Favorites, "<favorites>");
             });
             return item;
         }
 
-        tsl::elm::Element* createResetElement() {
-            auto item = new ActionListElement(emuiibo, "Reset active " + iconGlyph(Icon::Reset));
+        ActionListElement* createResetElement() {
+            auto item = new ActionListElement(emuiibo, TR("Reset active"), iconGlyph(Icon::Reset));
             item->setActionListener([this](auto&) {
                 emuiibo->ResetActiveVirtualAmiibo();
                 update();
@@ -771,8 +774,8 @@ class AmiiboGui : public tsl::Gui {
             return item;
         }
 
-        tsl::elm::Element* createHelpElement() {
-            auto item = new ActionListElement(emuiibo, "Help " + iconGlyph(Icon::Help));
+        ActionListElement* createHelpElement() {
+            auto item = new ActionListElement(emuiibo, TR("Help"), iconGlyph(Icon::Help));
             item->setActionListener([this](auto&) {
                 tsl::changeTo<AmiiboGuiHelp>(emuiibo);;
             });
@@ -815,6 +818,7 @@ class EmuiiboOverlay : public tsl::Overlay {
         }
 
         virtual void initServices() override {
+            Translator::global().loadSystem();
             emuiibo->initEmuiibo();
         }
 

--- a/overlay/source/translation.cpp
+++ b/overlay/source/translation.cpp
@@ -1,0 +1,79 @@
+extern "C" {
+#include <switch.h>
+#include <cstring>
+#define MIN_LNG_SIZE sizeof(u64) + 1
+void GetSystemLanguage(char* lng) {
+    u64 s_textLanguageCode = 0;
+    Result rc = setInitialize();
+    if (R_SUCCEEDED(rc)) rc = setGetSystemLanguage(&s_textLanguageCode);
+    setExit();
+    memset(lng, 0x00, MIN_LNG_SIZE);
+    memcpy(lng, (void*)&s_textLanguageCode, sizeof(s_textLanguageCode));
+}
+}
+
+#include <switch.h>
+#include <tesla.hpp>
+#include <translation.h>
+#include <filesystem>
+#include <fstream>
+#include <streambuf>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpessimizing-move"
+#include <json.hpp>
+#pragma GCC diagnostic pop
+
+Translator& Translator::global() {
+    static Translator glTr;
+    return glTr;
+}
+
+std::string Translator::translate(const std::string& source, const std::string& context) {
+    return global().get(source, context);
+}
+
+void Translator::loadSystem() {
+    char lng[MIN_LNG_SIZE];
+    GetSystemLanguage(lng);
+    loadCustom(lng);
+}
+
+void Translator::loadCustom(const std::string& lng) {
+    if (language == lng) {
+        return;
+    }
+    language = lng;
+    strings.clear();
+
+    tsl::hlp::doWithSDCardHandle([this] {
+        std::filesystem::path lng_file{"sdmc:/switch/.overlays/emuiibo/lng_" + language + ".json"};
+        if (!std::filesystem::exists(lng_file)) {
+            return;
+        }
+
+        std::ifstream json_file(lng_file);
+        const std::string json_string((std::istreambuf_iterator<char>(json_file)),
+                                std::istreambuf_iterator<char>());
+        auto json_all = json::JSON::Load(json_string);
+        for (auto json_string: json_all["strings"].ArrayRange()) {
+            const auto context = json_string["context"].ToString();
+            const auto source = json_string["source"].ToString();
+            const auto translation = json_string["translation"].ToString();
+            strings[context][source] = translation;
+        }
+    });
+}
+
+std::string Translator::get(const std::string& source, const std::string& context) const {
+    if (strings.count(context) == 0) {
+        return source;
+    }
+    if (strings.at(context).count(source) == 0) {
+        return source;
+    }
+    if (strings.at(context).at(source).empty()) {
+        return source;
+    }
+    return strings.at(context).at(source);
+}

--- a/overlay/tools/translation.py
+++ b/overlay/tools/translation.py
@@ -1,0 +1,221 @@
+#! /usr/bin/env python3
+
+import argparse
+import sys, os
+import re
+import json
+import collections
+import datetime
+
+PATH = os.path.abspath(os.path.dirname(__file__))
+
+
+class Translation:
+    def __init__(self, language):
+        self.language = language
+        self.keys = {}
+
+    def __str__(self):
+        result = "For language '%s':" % (self.language)
+        for ctx in self.ctx_list():
+            for source in self.sources_list(ctx):
+                translation = self.translation(ctx, source)
+                is_used = self.is_used(ctx, source)
+                special_characters_check = self.special_characters_check(source, translation)
+                result += '\n'
+                result += "%s " % (self.language)
+                if ctx is not "":
+                    result += "(%s) '%s'" % (ctx, source)
+                else:
+                    result += "'%s'" % (source)
+                if translation is None:
+                    result += " ! <not translated>"
+                else:
+                    result += " = '%s'" % (translation)
+                if not is_used:
+                    result += " ! <not used>"
+                if not special_characters_check:
+                    result += " ! <special characters mismatch>"
+        return result
+
+    def set(self, ctx, source, translation, is_used):
+        if ctx not in self.keys:
+            self.keys[ctx] = {}
+        if source not in self.keys[ctx]:
+            self.keys[ctx][source] = collections.namedtuple('Translation', 'translation is_used')
+        self.keys[ctx][source].translation = translation
+        self.keys[ctx][source].is_used = is_used
+
+    def translation(self, ctx, source):
+        if not self.is_exists(ctx, source):
+            return None
+        return self.keys[ctx][source].translation
+
+    def is_used(self, ctx, source):
+        if not self.is_exists(ctx, source):
+            return False
+        return self.keys[ctx][source].is_used
+
+    def special_characters_check(self, source, translation):
+        if source is None or translation is None:
+            return True
+        r = re.compile(r'[\.\,\:\;\\\/\(\)\[\]\{\}\?\!\&\%\"\'\*\+\~\<\>\|\=\-\r\n\t]')
+        count_source = collections.Counter(r.findall(source))
+        translation_source = collections.Counter(r.findall(translation))
+        return count_source == translation_source
+
+    def is_exists(self, ctx, source):
+        if ctx not in self.keys:
+            return False
+        if source not in self.keys[ctx]:
+            return False
+        return True
+
+    def ctx_list(self):
+        return self.keys.keys()
+
+    def sources_list(self, ctx):
+        if ctx not in self.keys:
+            return {}
+        return self.keys[ctx].keys()
+
+    def merge(self, addition, only_existing):
+        for ctx in addition.ctx_list():
+            for source in addition.sources_list(ctx):
+                translation = addition.translation(ctx, source)
+                is_used = addition.is_used(ctx, source)
+                exists = self.is_exists(ctx, source)
+                if exists:
+                    self.set(ctx, source, translation, True)
+                else:
+                    if not only_existing:
+                        self.set(ctx, source, translation, is_used)
+
+
+def load_sources(language):
+    used_keys = Translation(language)
+    file = open(PATH + '/../source/Main.cpp', 'r')
+    lines = file.readlines()
+    for line in lines:
+        r = re.compile(r'TR\(\s*"(.*?)"\s*\)')
+        pos = 0
+        while True:
+            m = r.search(line, pos)
+            if m is not None:
+                pos = m.span()[1]
+                ctx = ""
+                source = m.group(1)
+                used_keys.set(ctx, source, None, True)
+            else:
+                break
+        r = re.compile(r'TR_CTX\(\s*"(.*?)"\s*,\s*"(.*?)"\s*\)')
+        pos = 0
+        while True:
+            m = r.search(line, pos)
+            if m is not None:
+                pos = m.span()[1]
+                ctx = m.group(2)
+                source = m.group(1)
+                used_keys.set(ctx, source, None, True)
+            else:
+                break
+    return used_keys
+
+
+def load_translation(language):
+    given_keys = Translation(language)
+    metadata = None
+    file_name = PATH + '/../emuiibo/lng_' + language + '.json'
+    try:
+        file = open(file_name)
+        data = json.load(file)
+        metadata = data['metadata']
+        for str_entry in data['strings']:
+            ctx = str_entry['context']
+            source = str_entry['source']
+            translation = str_entry['translation']
+            given_keys.set(ctx, source, translation, False)
+    except:
+        print('%s not exists' % (file_name))
+    return (given_keys, metadata)
+
+
+def save_translation(language, result_keys, metadata):
+    file_name = PATH + '/../emuiibo/lng_' + language + '.json'
+    try:
+        data = {}
+        if metadata is None:
+            now =  datetime.datetime.now()
+            data['metadata'] = {}
+            data['metadata']['base'] = 'en'
+            data['metadata']['language'] = language
+            data['metadata']['created'] = "{}-{}-{}".format(now.year, now.month, now.day)
+            data['metadata']['author'] = ""
+        else:
+            data['metadata'] = metadata
+        data['strings'] = []
+        for ctx in result_keys.ctx_list():
+            for source in result_keys.sources_list(ctx):
+                translation = result_keys.translation(ctx, source)
+                data['strings'].append({
+                'context' : ctx,
+                'source' : source,
+                'translation' : translation})
+        file = open(file_name, 'w+')
+        json.dump(data, file, indent=4, ensure_ascii=False)
+        print('%s was created/updated' % (file_name))
+    except:
+        print('%s was not created' % (file_name))
+
+
+def check_language(language):
+    ava_lang = {
+        "ja": "Japanese",
+        "en-US": "AmericanEnglish",
+        "fr": "French",
+        "de": "German",
+        "it": "Italian",
+        "es": "Spanish",
+        "zh-CN": "Chinese",
+        "ko": "Korean",
+        "nl": "Dutch",
+        "pt": "Portuguese",
+        "ru": "Russian",
+        "zh-TW": "Taiwanese",
+        "en-GB": "BritishEnglish",
+        "fr-CA": "CanadianFrench",
+        "es-419": "LatinAmericanSpanish",
+        "zh-Hans": "[4.0.0+] SimplifiedChinese",
+        "zh-Hant": "[4.0.0+] TraditionalChinese",
+        "pt-BR": "[10.1.0+] BrazilianPortuguese",
+    };
+    if language not in ava_lang.keys():
+        raise Exception("Language code '%s' is wrong. Allowed: %s" % (language, ava_lang))
+
+
+def update(parser):
+    language = parser.language
+    check_language(language)
+    remove_unused = parser.remove_unused
+    used_keys = load_sources(language)
+    (given_keys, metadata) = load_translation(language)
+    result_keys = Translation(language)
+    result_keys.merge(used_keys, False)
+    result_keys.merge(given_keys, remove_unused)
+    save_translation(language, result_keys, metadata)
+    print(result_keys)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='command', help='Subcommand to run')
+
+    parser_update = subparsers.add_parser('update')
+    parser_update.add_argument(
+        '--remove-unused', action='store_true', help='Remove unused keys')
+    parser_update.add_argument(
+        'language', help='Language according https://switchbrew.org/wiki/Settings_services#LanguageCode')
+    parser_update.set_defaults(func=update)
+
+    options = parser.parse_args()
+    options.func(options)


### PR DESCRIPTION
Added support for localization.
I have used Qt like style (base strings in code) - I see as more readable in-comparison to ID based solutions.
To support fast update/create of translation extra make command added: `make translation `. Currently command updates only ru and de language, other can be added in similar way.

TR - default(empty) context
TR_CTX - custom context. Can be used to group strings or to add several translations for same source

P.S. Added translation for ru and de